### PR TITLE
add ByIndex version of generateMSDF functions

### DIFF
--- a/msdfgen/CMakeLists.txt
+++ b/msdfgen/CMakeLists.txt
@@ -90,21 +90,23 @@ target_include_directories(msdfgen_wasm PRIVATE
     "${CMAKE_CURRENT_LIST_DIR}/include"
     "${CMAKE_CURRENT_LIST_DIR}/wasm")
 set_target_properties(msdfgen_wasm PROPERTIES
-    LINK_FLAGS "-s EXPORTED_FUNCTIONS='[         \
-            \"_msdfgen_loadFontMemory\",         \
-            \"_msdfgen_getKerning\",             \
-            \"_msdfgen_generateMSDF\",           \
-            \"_msdfgen_generateAutoframedMSDF\", \
-            \"_msdfgen_result_getMSDFData\",     \
-            \"_msdfgen_result_getAdvance\",      \
-            \"_msdfgen_result_getTranslation\",  \
-            \"_msdfgen_result_getScale\",        \
-            \"_msdfgen_freeResult\",             \
-            \"_msdfgen_freeFont\"]'              \
-        -s 'EXPORTED_RUNTIME_METHODS=[     \
-            \"ccall\",                           \
-            \"cwrap\",                           \
-            \"getValue\"]'                       \
-        -s SINGLE_FILE=1                         \
-        --pre-js ${CMAKE_CURRENT_LIST_DIR}/wasm/pre.js \
+    LINK_FLAGS "-s EXPORTED_FUNCTIONS='[                \
+            \"_msdfgen_loadFontMemory\",                \
+            \"_msdfgen_getKerning\",                    \
+            \"_msdfgen_generateMSDF\",                  \
+            \"_msdfgen_generateMSDFByIndex\",           \
+            \"_msdfgen_generateAutoframedMSDF\",        \
+            \"_msdfgen_generateAutoframedMSDFByIndex\", \
+            \"_msdfgen_result_getMSDFData\",            \
+            \"_msdfgen_result_getAdvance\",             \
+            \"_msdfgen_result_getTranslation\",         \
+            \"_msdfgen_result_getScale\",               \
+            \"_msdfgen_freeResult\",                    \
+            \"_msdfgen_freeFont\"]'                     \
+        -s 'EXPORTED_RUNTIME_METHODS=[                  \
+            \"ccall\",                                  \
+            \"cwrap\",                                  \
+            \"getValue\"]'                              \
+        -s SINGLE_FILE=1                                \
+        --pre-js ${CMAKE_CURRENT_LIST_DIR}/wasm/pre.js  \
         --post-js ${CMAKE_CURRENT_LIST_DIR}/wasm/post.js")

--- a/msdfgen/ext/import-font.h
+++ b/msdfgen/ext/import-font.h
@@ -25,6 +25,8 @@ bool getFontScale(double &output, FontHandle *font);
 bool getFontWhitespaceWidth(double &spaceAdvance, double &tabAdvance, FontHandle *font);
 /// Loads the shape prototype of a glyph from font file
 bool loadGlyph(Shape &output, FontHandle *font, int unicode, double *advance = NULL);
+/// Loads the shape prototype of a glyph from font file by glyph index
+bool loadGlyphByIndex(Shape &output, FontHandle *font, int index, double *advance = NULL);
 /// Returns the kerning distance adjustment between two specific glyphs.
 bool getKerning(double &output, FontHandle *font, int unicode1, int unicode2);
 

--- a/msdfgen/wasm/msdfgen_c.cpp
+++ b/msdfgen/wasm/msdfgen_c.cpp
@@ -149,6 +149,39 @@ MSDFGenResult* msdfgen_generateMSDF(
                 overlapSupport);
 }
 
+MSDFGenResult* msdfgen_generateMSDFByIndex(
+        int width,
+        int height,
+        msdfgen::FontHandle *fontHandle,
+        int index,
+        double edgeColoringAngleThreshold,
+        double range,
+        double scale_x,
+        double scale_y,
+        double translate_x,
+        double translate_y,
+        double edgeThreshold,
+        char overlapSupport)
+{
+    double advance;
+    msdfgen::Shape shape;
+    if (!msdfgen::loadGlyphByIndex(shape, fontHandle, index, &advance)) {
+        return nullptr;
+    }
+    edgeColoringSimple(shape, edgeColoringAngleThreshold);
+
+    return generateMSDFResult(
+                width,
+                height,
+                shape,
+                advance,
+                range,
+                {scale_x, scale_y},
+                {translate_x, translate_y},
+                edgeThreshold,
+                overlapSupport);
+}
+
 MSDFGenResult* msdfgen_generateAutoframedMSDF(
         int width,
         int height,
@@ -186,6 +219,45 @@ MSDFGenResult* msdfgen_generateAutoframedMSDF(
                 edgeThreshold,
                 overlapSupport);
 }
+
+MSDFGenResult* msdfgen_generateAutoframedMSDFByIndex(
+        int width,
+        int height,
+        msdfgen::FontHandle *fontHandle,
+        int index,
+        double edgeColoringAngleThreshold,
+        double range,
+        double max_scale,
+        double edgeThreshold,
+        char overlapSupport)
+{
+    double advance = 0.0;
+
+    msdfgen::Vector2 translate;
+    double scale = 1.0;
+
+    msdfgen::Shape shape;
+    if (!msdfgen::loadGlyphByIndex(shape, fontHandle, index, &advance)) {
+        return nullptr;
+    }
+
+    autoframe(shape, width, height, range, translate, scale);
+    scale = std::min(max_scale, scale);
+
+    edgeColoringSimple(shape, edgeColoringAngleThreshold);
+
+    return generateMSDFResult(
+                width,
+                height,
+                shape,
+                advance,
+                range,
+                {scale,scale},
+                translate,
+                edgeThreshold,
+                overlapSupport);
+}
+
 
 float *msdfgen_result_getMSDFData(MSDFGenResult *result)
 {

--- a/msdfgen/wasm/msdfgen_c.h
+++ b/msdfgen/wasm/msdfgen_c.h
@@ -57,6 +57,21 @@ MSDFGenResult* msdfgen_generateMSDF(
         double edgeThreshold = 1.001,
         char overlapSupport = 1);
 
+MSDFGenResult* msdfgen_generateMSDFByIndex(
+        int width,
+        int height,
+        msdfgen::FontHandle *fontHandle,
+        int index,
+        double edgeColoringAngleThreshold,
+        double range,
+        double scale_x,
+        double scale_y,
+        double translate_x,
+        double translate_y,
+        double edgeThreshold = 1.001,
+        char overlapSupport = 1);
+
+
 /*
  * Generate MSDF with autoframe
  *
@@ -69,6 +84,17 @@ MSDFGenResult* msdfgen_generateAutoframedMSDF(
         int height,
         msdfgen::FontHandle *fontHandle,
         int unicode,
+        double edgeColoringAngleThreshold,
+        double range,
+        double max_scale,
+        double edgeThreshold = 1.001,
+        char overlapSupport = 1);
+
+MSDFGenResult* msdfgen_generateAutoframedMSDFByIndex(
+        int width,
+        int height,
+        msdfgen::FontHandle *fontHandle,
+        int index,
         double edgeColoringAngleThreshold,
         double range,
         double max_scale,

--- a/msdfgen/wasm/msdfgen_c.h
+++ b/msdfgen/wasm/msdfgen_c.h
@@ -38,7 +38,7 @@ double msdfgen_getKerning(
         int right_unicode);
 
 /*
- * Generate MSDF with autoframe
+ * Generate MSDF
  *
  * This function returns some glyph metadata usable for text rendering.
  * The returned object must be freed by caller using msdfgen_freeResult.
@@ -57,6 +57,12 @@ MSDFGenResult* msdfgen_generateMSDF(
         double edgeThreshold = 1.001,
         char overlapSupport = 1);
 
+/*
+ * Generate MSDF
+ *
+ * A variant of `msdfgen_generateMSDF`, where the glyph is identified by
+ * its index in the font file instead of unicode codepoint.
+ */
 MSDFGenResult* msdfgen_generateMSDFByIndex(
         int width,
         int height,
@@ -90,6 +96,12 @@ MSDFGenResult* msdfgen_generateAutoframedMSDF(
         double edgeThreshold = 1.001,
         char overlapSupport = 1);
 
+/*
+ * Generate MSDF with autoframe
+ *
+ * A variant of `msdfgen_generateMSDF`, where the glyph is identified by
+ * its index in the font file instead of unicode codepoint.
+ */
 MSDFGenResult* msdfgen_generateAutoframedMSDFByIndex(
         int width,
         int height,


### PR DESCRIPTION
### Pull Request Description

For @wdanilo request, this PR adds variants of generateMSDF functions where the glyph index is taken instead of Unicode code point.

### Important Notes


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code has been tested where possible.
