### PR TITLE
Allow memory growth and bump emscripten

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup emsdk
       uses: mymindstorm/setup-emsdk@v10
       with:
-        version: 3.1.13
+        version: 3.1.24
     - name: Install cmake
       run: sudo apt-get install cmake
     - name: Build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup emsdk
       uses: mymindstorm/setup-emsdk@v10
       with:
-        version: 3.1.13
+        version: 3.1.24
     - name: Install cmake
       run: sudo apt-get install cmake
     - name: Build

--- a/freetype2/builds/unix/ftsystem.c
+++ b/freetype2/builds/unix/ftsystem.c
@@ -26,9 +26,7 @@
 #include <freetype/internal/ftstream.h>
 
   /* memory-mapping includes and definitions */
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 
 #include <sys/mman.h>
 #ifndef MAP_FILE
@@ -60,9 +58,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
-#ifdef HAVE_FCNTL_H
 #include <fcntl.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/msdfgen/CMakeLists.txt
+++ b/msdfgen/CMakeLists.txt
@@ -109,5 +109,6 @@ set_target_properties(msdfgen_wasm PROPERTIES
             \"cwrap\",                                  \
             \"getValue\"]'                              \
         -s SINGLE_FILE=1                                \
+        -s ALLOW_MEMORY_GROWTH=1                        \
         --pre-js ${CMAKE_CURRENT_LIST_DIR}/wasm/pre.js  \
         --post-js ${CMAKE_CURRENT_LIST_DIR}/wasm/post.js")


### PR DESCRIPTION
### Pull Request Description
Once the msdgen_wasm library was used to load more fonts we start to go over the memory limit. This PR adds an option for allowing memory growth.

Also bumped emscripten version on CI, to match the version where the code is tested
It required one workaround for bug https://github.com/emscripten-core/emscripten/issues/17007

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code has been tested where possible.
